### PR TITLE
replace tap with native test runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ dist
 
 # TernJS port file
 .tern-port
+.idea

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Modern FileSystem (fs) utilities to lazy walk directories Asynchronously (but also Synchronously)",
   "exports": "./index.js",
   "scripts": {
-    "lint": "cross-env eslint index.js",
-    "test-only": "cross-env esm-tape-runner 'test/**/*.js' | tap-monkey",
+    "lint": "eslint index.js",
+    "test-only": "node --test",
     "test": "npm run lint && npm run test-only",
     "coverage": "c8 -r html npm test"
   },
@@ -35,11 +35,7 @@
   "homepage": "https://github.com/NodeSecure/fs-walk#readme",
   "devDependencies": {
     "@nodesecure/eslint-config": "^1.5.0",
-    "@small-tech/esm-tape-runner": "^2.0.0",
-    "@small-tech/tap-monkey": "^1.4.0",
-    "c8": "^7.12.0",
-    "cross-env": "^7.0.3",
-    "tape": "^5.6.0"
+    "c8": "^7.12.0"
   },
   "type": "module"
 }

--- a/test/walk.js
+++ b/test/walk.js
@@ -1,4 +1,5 @@
-import test from "tape";
+import test from "node:test";
+import assert from "node:assert"
 
 // Require Node.js Dependencies
 import path from "path";
@@ -12,46 +13,48 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const kRootLocation = path.join(__dirname, "..");
 const kFixturesDir = path.join(__dirname, "fixtures");
-const kExpectedJSFiles = [
-  "index.js",
-  "test/walk.js"
-].map((fileLocation) => path.normalize(fileLocation));
+const kExpectedJSFiles = ["index.js", "test/walk.js"].map((fileLocation) =>
+  path.normalize(fileLocation)
+);
 
-test("should return all JavaScript files of the project (Asynchronously)", async(tape) => {
+test("should return all JavaScript files of the project (Asynchronously)", async (t) => {
   const files = [];
   const options = { extensions: new Set([".js"]) };
 
-  for await (const [dirent, absoluteFileLocation] of walk(kRootLocation, options)) {
+  for await (const [dirent, absoluteFileLocation] of walk(
+    kRootLocation,
+    options
+  )) {
     if (dirent.isFile()) {
       files.push(path.relative(kRootLocation, absoluteFileLocation));
     }
   }
 
-  tape.deepEqual(files, kExpectedJSFiles);
-  tape.end();
+  assert.deepEqual(files, kExpectedJSFiles);
 });
 
-test("should return all JavaScript files of the project (Synchronously)", async(tape) => {
+test("should return all JavaScript files of the project (Synchronously)", async (t) => {
   const options = { extensions: new Set([".js"]) };
 
   const files = [...walkSync(kRootLocation, options)]
     .filter(([dirent]) => dirent.isFile())
-    .map(([, absoluteFileLocation]) => path.relative(kRootLocation, absoluteFileLocation));
+    .map(([, absoluteFileLocation]) =>
+      path.relative(kRootLocation, absoluteFileLocation)
+    );
 
-  tape.deepEqual(files, kExpectedJSFiles);
-  tape.end();
+  assert.deepEqual(files, kExpectedJSFiles);
 });
 
-test("should return all files in the fixtures directory", async(tape) => {
+test("should return all files in the fixtures directory", async (t) => {
   const files = [...walkSync(kFixturesDir)]
     .filter(([dirent]) => dirent.isFile())
-    .map(([, absoluteFileLocation]) => path.relative(kRootLocation, absoluteFileLocation));
+    .map(([, absoluteFileLocation]) =>
+      path.relative(kRootLocation, absoluteFileLocation)
+    );
 
   const expectedFiles = [
     "test/fixtures/foobar.txt",
-    "test/fixtures/test.md"
+    "test/fixtures/test.md",
   ].map((fileLocation) => path.normalize(fileLocation));
-  tape.deepEqual(files, expectedFiles);
-  tape.end();
+  assert.deepEqual(files, expectedFiles);
 });
-


### PR DESCRIPTION
I have made my first contribution to an open source project by replacing the tap test runner with the native Node.js 18.x test runner, and removing the unnecessary cross-env dependency.